### PR TITLE
Fix VMAT SCP MU scaling and clinical criteria logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ docs/_build/
 /results/
 /metadata/
 /examples/hugging_face_data/
+.DS_Store

--- a/portpy/photon/clinical_criteria.py
+++ b/portpy/photon/clinical_criteria.py
@@ -140,34 +140,38 @@ class ClinicalCriteria:
         return all_criteria
 
     def check_criterion_exists(self, criterion, return_ind:bool = False):
-        criterion_exist = False
-        criterion_ind = None
-        for ind, crit in enumerate(self.clinical_criteria_dict['criteria']):
-            if (crit['type'] == criterion['type']) and crit['parameters'] == criterion['parameters']:
-                for constraint in crit['constraints']:
-                    if constraint == criterion['constraints']:
-                        criterion_exist = True
-                        criterion_ind = ind
-        if return_ind:
-            return criterion_exist,criterion_ind
-        else:
-            return criterion_exist
+            criterion_exist = False
+            criterion_ind = None
+            for ind, crit in enumerate(self.clinical_criteria_dict['criteria']):
+                if (crit['type'] == criterion['type']) and crit['parameters'] == criterion['parameters']:
+                    for constraint in crit['constraints']:
+                        for key, _ in criterion['constraints'].items():
+                            if constraint == key:
+                                criterion_exist = True
+                                criterion_ind = ind
+            if return_ind:
+                return criterion_exist,criterion_ind
+            else:
+                return criterion_exist
 
     def modify_criterion(self, criterion):
         """
-        Modify the criterion the clinical criteria
-
-
+        Update constraints for an existing criterion.
+        Only updates keys that already exist in the original constraint dict.
         """
-        criterion_found = False
         for ind, crit in enumerate(self.clinical_criteria_dict['criteria']):
-            if (crit['type'] == criterion['type']) and crit['parameters'] == criterion['parameters']:
-                for constraint in crit['constraints']:
-                    if constraint == criterion['constraints']:
-                        self.clinical_criteria_dict['criteria'][ind]['constraints'][constraint] = criterion['constraints']
-                        criterion_found = True
-        if not criterion_found:
-            raise Warning('No criteria  for {}'.format(criterion))
+
+            if crit['type'] == criterion['type'] and crit['parameters'] == criterion['parameters']:
+                existing_keys = crit['constraints']
+                updated = False
+                for key, value in criterion.get('constraints', {}).items():
+                    if key in existing_keys:
+                        existing_keys[key] = value
+                        updated = True
+                if updated:
+                    return
+
+        raise Warning(f"No criteria found for {criterion}")
 
 
     def get_num(self, string: Union[str, float]):

--- a/portpy/photon/vmat_scp/vmat_scp_optimization.py
+++ b/portpy/photon/vmat_scp/vmat_scp_optimization.py
@@ -1178,7 +1178,7 @@ class VmatScpOptimization(Optimization):
             + cp.multiply(bound_v_r, card_bound_inds_r)]
         # generic constraints for relation between interior and boundary beamlets
         constraints += [leaf_pos_mu_r - leaf_pos_mu_l >= int_v[map_int_v]]
-        constraints += [int_v >= self.vmat_params['mu_min']]
+        constraints += [int_v*100 >= self.vmat_params['mu_min']] # multiply it by 100 to match eclipse mu
         constraints += [bound_v_l <= int_v[map_int_v]]
         constraints += [bound_v_r <= int_v[map_int_v]]
         if 'minimum_dynamic_leaf_gap_mm' in self.vmat_params:


### PR DESCRIPTION
### Summary

This PR includes a small set of fixes:

1. Fix MU scaling in the VMAT SCP intermediate optimization to match Eclipse MU.
2. Fix the `clinical_criteria` logic when checking and modifying criteria.

---

### Changes

#### 1. VMAT SCP MU scaling fix

In `portpy/photon/vmat_scp/vmat_scp_optimization.py`:

Adjust the lower-bound constraint on the interior beamlet intensities from:

```python
constraints += [int_v >= self.vmat_params['mu_min']]
```

to 

```python
constraints += [int_v * 100 >= self.vmat_params['mu_min']]
```

This aligns MU handling within the SCP intermediate optimization with Eclipse’s MU scaling.

#### 2. Clinical criteria handling

Both `modify_criterion()` and `check_criterion_exists()` contained the same logical error:
they compared a constraint key (string) to the entire constraint dictionary, which always evaluated to false.

The updated logic now:
1. Properly matches criteria by type and parameters,
2. Iterates through the relevant constraint keys,
3. Updates only existing keys in the stored constraint dictionary,
4. Raises a clear warning if no matching criterion is found.