### PR TITLE
Add CVaR upper constraint helper in Optimization

### DIFF
--- a/portpy/photon/clinical_criteria.py
+++ b/portpy/photon/clinical_criteria.py
@@ -267,6 +267,9 @@ class ClinicalCriteria:
         df = pd.DataFrame()
         count = 0
         for i in range(len(dvh_updated_list)):
+
+            dvh_method =  dvh_updated_list[i]['parameters'].get('dvh_method', None)
+
             if 'dose_volume_V' in dvh_updated_list[i]['type']:
                 limit_key = self.matching_keys(dvh_updated_list[i]['constraints'], 'limit')
                 dose_key = self.matching_keys(dvh_updated_list[i]['parameters'], 'dose_')
@@ -275,6 +278,7 @@ class ClinicalCriteria:
                     df.at[count, 'dose_gy'] = self.dose_to_gy(dose_key, dvh_updated_list[i]['parameters'][dose_key])
                     df.at[count, 'volume_perc'] = dvh_updated_list[i]['constraints'][limit_key]
                     df.at[count, 'dvh_type'] = 'constraint'
+                    df.at[count, 'dvh_method'] = dvh_method
                     count = count + 1
                 goal_key = self.matching_keys(dvh_updated_list[i]['constraints'], 'goal')
                 if goal_key in dvh_updated_list[i]['constraints']:
@@ -282,6 +286,7 @@ class ClinicalCriteria:
                     df.at[count, 'dose_gy'] = self.dose_to_gy(dose_key, dvh_updated_list[i]['parameters'][dose_key])
                     df.at[count, 'volume_perc'] = dvh_updated_list[i]['constraints'][goal_key]
                     df.at[count, 'dvh_type'] = 'goal'
+                    df.at[count, 'dvh_method'] = dvh_method
                     df.at[count, 'weight'] = dvh_updated_list[i]['parameters']['weight']
                     count = count + 1
             if 'dose_volume_D' in dvh_updated_list[i]['type']:
@@ -290,6 +295,7 @@ class ClinicalCriteria:
                     df.at[count, 'structure_name'] = dvh_updated_list[i]['parameters']['structure_name']
                     df.at[count, 'volume_perc'] = dvh_updated_list[i]['parameters']['volume_perc']
                     df.at[count, 'dose_gy'] = self.dose_to_gy(limit_key, dvh_updated_list[i]['constraints'][limit_key])
+                    df.at[count, 'dvh_method'] = dvh_method
                     df.at[count, 'dvh_type'] = 'constraint'
                     count = count + 1
                 goal_key = self.matching_keys(dvh_updated_list[i]['constraints'], 'goal')
@@ -297,6 +303,7 @@ class ClinicalCriteria:
                     df.at[count, 'structure_name'] = dvh_updated_list[i]['parameters']['structure_name']
                     df.at[count, 'volume_perc'] = dvh_updated_list[i]['parameters']['volume_perc']
                     df.at[count, 'dose_gy'] = self.dose_to_gy(goal_key, dvh_updated_list[i]['constraints'][goal_key])
+                    df.at[count, 'dvh_method'] = dvh_method
                     df.at[count, 'dvh_type'] = 'goal'
                     df.at[count, 'weight'] = dvh_updated_list[i]['parameters']['weight']
                     count = count + 1


### PR DESCRIPTION
Usage

- JSON configuration:
  - Add a constraint entry with `"type": "CVaR_Upper"`.
  - Required fields:
    - `parameters.structure_name` (e.g., `"HEART"`)
    - `parameters.alpha` (e.g., `0.90`)
    - `constraints.limit` (CVaR upper limit on total dose, in Gy)

- Programmatic API:
  - Construct an `Optimization` object using the standard workflow.
  - Add the constraint, for example:
    `opt.add_CVaR_Upper(alpha=0.90, limit=5, struct="HEART")`
  - Solve the optimization problem using the existing solve workflow.
